### PR TITLE
Move "Global Settings" and search out of nav

### DIFF
--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -2,39 +2,43 @@
   .navbar-inner
     .container
       = link_to app_name, :root, class: "brand"
-      - if session_user.nil?
-        %ul.nav.pull-right.hide-from-print
-          %li= link_to t("pages.login"), :new_user_session
-      - else
+      - if responsive?
+        %a.btn.btn-navbar.hide-from-print{ data: { target: ".nav-collapse", toggle: "collapse" } }
+          %span.fa.fa-lg.fa-bars
+            -# collapsed at < 979px
+      .hide-from-print{ class: ("nav-collapse collapse" if responsive?) }
         - if responsive?
-          %a.btn.btn-navbar.hide-from-print{ data: { target: ".nav-collapse", toggle: "collapse" } }
-            %span.fa.fa-lg.fa-bars
-        -# collapsed at < 979px
-        .hide-from-print{ class: ("nav-collapse collapse" if responsive?) }
-          - if responsive?
-            -# .hidden-with-nav is hidden > 979px
-            .hidden-with-nav
-              = render "/shared/nav/nav_links"
-          %ul.nav.pull-right.hide-from-print
-            - if acting_as?
-              %li.navbar-text= "#{acting_user.full_name} (#{acting_user.username})"
-              %li= link_to "#{t('pages.cart')} (#{current_cart.order_details.count})", :cart
+          -# .hidden-with-nav is hidden > 979px
+          .hidden-with-nav
+            = render "/shared/nav/nav_links"
+        %ul.nav.pull-right.hide-from-print
+          - if acting_as?
+            %li.navbar-text= "#{acting_user.full_name} (#{acting_user.username})"
+            %li= link_to "#{t('pages.cart')} (#{current_cart.order_details.count})", :cart
+          - elsif current_user
+            - if UserPreference.options_for(current_user).any?
+              %li.visible-with-link= link_to "#{current_user.full_name} (#{current_user.username})", user_user_preferences_path(current_user)
             - else
-              - if UserPreference.options_for(current_user).any?
-                %li.visible-with-link= link_to "#{current_user.full_name} (#{current_user.username})", user_user_preferences_path(current_user)
-              - else
-                %li.navbar-text= "#{acting_user.full_name} (#{acting_user.username})"
-              %li.divider-vertical
+              %li.navbar-text= "#{acting_user.full_name} (#{acting_user.username})"
+            %li.divider-vertical
               - if current_user.password_updatable? && SettingsHelper.feature_on?(:password_update)
                 %li= link_to t("user_password.edit.head"), :edit_current_password
-                %li.divider-vertical
-              -# .visible-with-nav is visible > 979px
-              %li.visible-with-nav= link_to t('pages.cart') + " (#{current_cart.order_details.count})", :cart
               %li.divider-vertical
+                -# .visible-with-nav is visible > 979px
+            - if current_user
+              %li.visible-with-nav= link_to t('pages.cart') + " (#{current_cart.order_details.count})", :cart
+            %li.divider-vertical
               = render "shared/message_summary"
-              %li= link_to t('pages.logout'), sign_out_user_path
-              - if responsive? && !acting_as? && current_user
-                = form_tag global_search_path, class: "navbar-search pull-right hidden-with-nav" do
-                  = text_field_tag :search, nil, placeholder: t("global_search.search"), class: "search-query span2"
+          - global_navigation_links.each do |link|
+            %li{class: link.tab_class(controller)}= link.to_html
+            %li.divider-vertical
+          = form_tag global_search_path, class: "navbar-search" do
+            = text_field_tag :search, nil, placeholder: t("global_search.search"), class: "search-query span2"
+          %li.divider-vertical
+          - if session_user.nil?
+            %li= link_to t('pages.login'), :new_user_session
+          - else
+            %li= link_to t('pages.logout'), sign_out_user_path
+
 
 

--- a/app/views/shared/_nav.html.haml
+++ b/app/views/shared/_nav.html.haml
@@ -2,8 +2,4 @@
 .navbar.navbar-static-top.hide-from-print.visible-with-nav
   .navbar-inner
     .container
-      - if session_user
-        = render "/shared/nav/nav_links"
-      - else
-        = form_tag global_search_path, class: "navbar-search pull-right visible-with-nav" do
-          = text_field_tag :search, nil, placeholder: t("global_search.search"), class: "search-query span2"
+      = render "/shared/nav/nav_links"

--- a/app/views/shared/nav/_nav_links.html.haml
+++ b/app/views/shared/nav/_nav_links.html.haml
@@ -1,5 +1,5 @@
 %ul.nav
-  - if responsive?
+  - if responsive? && current_user
     -# .hidden-with-nav is hidden > 979px
     %li.hidden-with-nav= link_to t('pages.cart') + " (#{current_cart.order_details.count})", :cart
   - navigation_links.each do |link|
@@ -15,12 +15,6 @@
       - else
         = link.to_html
 
--# .visible-with-nav is visible > 979px
-= form_tag global_search_path, class: "navbar-search pull-right visible-with-nav" do
-  = text_field_tag :search, nil, placeholder: t("global_search.search"), class: "search-query span2"
-
 -# trailing "<" enables use of .nav-collapse .nav:empty in boostrap-responsive-overrides.scss
 %ul.nav.pull-right<
   = render "shared/nav/manage_facilities"
-  - global_navigation_links.each do |link|
-    %li{class: link.tab_class(controller)}= link.to_html


### PR DESCRIPTION
# Release Notes
This change moves the global settings links and search bar out of the navigation bar. It helps eliminate the content in the pull-right section of the nav, simplifying the design.

# Screenshot
## Before
<img width="1011" alt="screen shot 2018-05-17 at 1 31 19 pm" src="https://user-images.githubusercontent.com/3682844/40194076-32d9831e-59d7-11e8-9713-b8886604075e.png">
<img width="1010" alt="screen shot 2018-05-17 at 1 31 27 pm" src="https://user-images.githubusercontent.com/3682844/40194077-32e9265c-59d7-11e8-89c7-c05a32dfd978.png">
<img width="1010" alt="screen shot 2018-05-17 at 1 31 36 pm" src="https://user-images.githubusercontent.com/3682844/40194079-32ff3988-59d7-11e8-9ace-47987ce65058.png">

## After
<img width="1009" alt="screen shot 2018-05-17 at 1 30 23 pm" src="https://user-images.githubusercontent.com/3682844/40194090-3e4665d2-59d7-11e8-8c08-7339c17ee160.png">
<img width="1010" alt="screen shot 2018-05-17 at 1 30 48 pm" src="https://user-images.githubusercontent.com/3682844/40194091-3e559bc4-59d7-11e8-911c-32a229d61a0c.png">
<img width="1010" alt="screen shot 2018-05-17 at 1 30 58 pm" src="https://user-images.githubusercontent.com/3682844/40194092-3e630b6a-59d7-11e8-9b78-87192c4cf30b.png">



# Additional Context

This is part of a larger set of changes to the design.