### PR TITLE
Change strings in layout

### DIFF
--- a/config/locales/override/en.yml
+++ b/config/locales/override/en.yml
@@ -1,6 +1,6 @@
 # Put any locale overrides specific to your fork in this file
 en:
-  # app_name: NUcore
+  app_name: CIDER
   # institution_name: Northwestern
 
   # shared:

--- a/config/locales/override/en.yml
+++ b/config/locales/override/en.yml
@@ -3,10 +3,10 @@ en:
   app_name: CIDER
   institution_name: UConn
 
-  # shared:
-  #   footer:
-  #     copyright_html: "&copy; Copyright 2011%{to_date} Northwestern University"
-  #     logo_alt: "Northwestern University Logo"
+  shared:
+    footer:
+      copyright_html: "&copy; Copyright 2018&ndash;%{to_date} University of Connecticut"
+      logo_alt: "UConn Logo"
 
   testing: # DO NOT DELETE: these are used to verify proper file loading in the specs
     locale_loading: This is here to verify the file is loaded in the specs

--- a/config/locales/override/en.yml
+++ b/config/locales/override/en.yml
@@ -1,7 +1,7 @@
 # Put any locale overrides specific to your fork in this file
 en:
   app_name: CIDER
-  # institution_name: Northwestern
+  institution_name: UConn
 
   # shared:
   #   footer:


### PR DESCRIPTION
# Release Notes

There are some references to NU (especially the app's name). This change makes some text items (app name, institution name, copyright text, logo alt-text) in the layout more UConn-appropriate.

# Screenshot

## Before 
<img width="1061" alt="screen shot 2018-05-24 at 10 31 17 am" src="https://user-images.githubusercontent.com/3682844/40492864-7720d9ec-5f3f-11e8-83f3-2aefeda36f02.png">

## After
<img width="1060" alt="screen shot 2018-05-24 at 10 43 35 am" src="https://user-images.githubusercontent.com/3682844/40492826-5ec5afbc-5f3f-11e8-9985-6ef3e9b27b62.png">