### PR TITLE
change git_source in Gemfile to use HTTPS instead of SSH

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 ruby File.open(File.expand_path(".ruby-version", File.dirname(__FILE__))) { |f| f.read.chomp }
 
-git_source(:github) { |repo_name| "git@github.com:#{repo_name}.git" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 ## base
 gem "rails", "5.0.7"


### PR DESCRIPTION
# Release Notes

The use of SSH for gem sources was breaking some automated tests I have been running.

For example, on a fresh VM the `bundle install` step cannot be run
non-interactively due to the host key checking stage when using SSH.

This will resolve those issues and ensure `bundle install` can be
run non-interactively for testing purposes.

As far as I can tell there is no downside to using https for gems,
and when I asked Vlad he saw no issue with it either.

