### PR TITLE
Feature/uconn ldap integration

### DIFF
--- a/vendor/engines/ldap_authentication/lib/ldap_authentication/engine.rb
+++ b/vendor/engines/ldap_authentication/lib/ldap_authentication/engine.rb
@@ -11,7 +11,9 @@ module LdapAuthentication
       if LdapAuthentication.configured?
         User.send(:devise, :ldap_authenticatable)
         User.send(:include, LdapAuthentication::UserExtension)
-        UsersController.send(:include, LdapAuthentication::UsersControllerExtension)
+        # UConn overrides this with our own customization in the nucore_kfs engine
+        # TODO: is there a better way to disable this and ensure the nucore_kfs engine takes precedence?
+        # UsersController.send(:include, LdapAuthentication::UsersControllerExtension)
       end
     end
 

--- a/vendor/engines/nucore_kfs/app/services/nucore_kfs/chart_of_accounts.rb
+++ b/vendor/engines/nucore_kfs/app/services/nucore_kfs/chart_of_accounts.rb
@@ -157,6 +157,9 @@ module NucoreKfs
       else
         puts("Did not find user with NetID #{netid} in database. Creating from LDAP...")
         user_info = @user_lookup.findByNetId(netid)
+        if user_info.nil?
+          return nil
+        end
         puts("LDAP found user with NetID #{netid} (email: #{user_info.mail}).")
 
         begin

--- a/vendor/engines/nucore_kfs/app/services/nucore_kfs/chart_of_accounts.rb
+++ b/vendor/engines/nucore_kfs/app/services/nucore_kfs/chart_of_accounts.rb
@@ -170,7 +170,7 @@ module NucoreKfs
           user.create_default_price_group!
           user
         rescue ActiveRecord::RecordInvalid
-          puts("Received ActiveRecord::RecordInvalid.")
+          puts("Received ActiveRecord::RecordInvalid. Netid: #{netid} | email: #{user_info.mail}")
           nil
         end
       end
@@ -200,9 +200,6 @@ module NucoreKfs
         return
       end
       puts("account_number = #{account_number} | account_owner = #{account_owner.id} | business_admin = #{business_admin.id}")
-
-      # FIXME: temp for analysis
-      return
 
       account = Account.find_by(account_number: account_number)
       # if the account is not in our DB yet, and it is 'OPEN', then build a record for it

--- a/vendor/engines/nucore_kfs/app/services/nucore_kfs/uconn_user_lookup.rb
+++ b/vendor/engines/nucore_kfs/app/services/nucore_kfs/uconn_user_lookup.rb
@@ -51,6 +51,15 @@ module NucoreKfs
       end
     end
 
+    def makeNucoreUserFromLdapUser(ldap_user)
+      User.new(
+        :username => ldap_user.uid,
+        :first_name => ldap_user.givenname,
+        :last_name => ldap_user.sn,
+        :email => ldap_user.mail,
+      )
+    end
+
   end
 
 end

--- a/vendor/engines/nucore_kfs/app/services/nucore_kfs/uconn_user_lookup.rb
+++ b/vendor/engines/nucore_kfs/app/services/nucore_kfs/uconn_user_lookup.rb
@@ -1,0 +1,56 @@
+module NucoreKfs
+
+  class UconnLdapUser
+    attr_accessor :uid, :cn, :sn, :mail, :givenname
+    def initialize(ldap_entry)
+      @uid = ldap_entry.uid.first
+      @cn = ldap_entry.cn.first
+      @sn = ldap_entry.sn.first
+      @mail = ldap_entry.mail.first
+      @givenname = ldap_entry.givenname.first
+    end
+  end
+
+  class UconnUserLookup
+
+    def initialize
+      # Load config
+      config_file_path = Rails.root.join("config", "ldap.yml")
+      parsed = ERB.new(File.read(config_file_path)).result
+      yaml = YAML.safe_load(parsed, [], [], true) || {}
+      config = yaml.fetch(Rails.env, {})
+      host = config.fetch("host", "")
+      port = config.fetch("port", "")
+      admin_user = config.fetch("admin_user", "")
+      admin_password = config.fetch("admin_password", "")
+      @treebase = config.fetch("base", "")
+
+      # init LDAP connection
+      ldap = Net::LDAP.new(:encryption => {:method => :start_tls})
+      ldap.host = host
+      ldap.port = port
+      ldap.auth admin_user, admin_password
+
+      # Bind and store result for later use
+      @bindSuccess = ldap.bind
+      @ldap = ldap
+    end
+
+    def status
+      @ldap.get_operation_result
+    end
+
+    def findByNetId(netid)
+      filter = Net::LDAP::Filter.eq('uid', netid)
+      results = @ldap.search( :base => @treebase, :filter => filter )
+      entry = results.first
+      if entry.nil?
+        nil
+      else 
+        UconnLdapUser.new(entry)
+      end
+    end
+
+  end
+
+end

--- a/vendor/engines/nucore_kfs/lib/nucore_kfs/engine.rb
+++ b/vendor/engines/nucore_kfs/lib/nucore_kfs/engine.rb
@@ -6,6 +6,9 @@
 # require "nucore_kfs/import_uch_banner_index"
 # require "nucore_kfs/uch_banner_export"
 
+require "nucore_kfs/users_controller_extension"
+
+
 module NucoreKfs
   class Engine < ::Rails::Engine
 
@@ -17,6 +20,8 @@ module NucoreKfs
       ViewHook.add_hook "facility_journals.downloads",
                         "other_formats",
                         "uch_banner_csv_partial"
+
+      UsersController.send(:include, NucoreKfs::UsersControllerExtension)
     end
 
     initializer :append_migrations do |app|
@@ -30,7 +35,6 @@ module NucoreKfs
         FactoryBot.definition_file_paths << File.expand_path("../../../spec/factories", __FILE__) if defined?(FactoryBot)
       end
     end
-
 
   end
 

--- a/vendor/engines/nucore_kfs/lib/nucore_kfs/users_controller_extension.rb
+++ b/vendor/engines/nucore_kfs/lib/nucore_kfs/users_controller_extension.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module NucoreKfs
+
+  module UsersControllerExtension
+
+    def service_username_lookup(username)
+      lookup = NucoreKfs::UconnUserLookup.new
+      ldap_user = lookup.findByNetId(username)
+      lookup.makeNucoreUserFromLdapUser(ldap_user)
+    end
+
+  end
+
+end

--- a/vendor/engines/nucore_kfs/lib/nucore_kfs/users_controller_extension.rb
+++ b/vendor/engines/nucore_kfs/lib/nucore_kfs/users_controller_extension.rb
@@ -7,6 +7,9 @@ module NucoreKfs
     def service_username_lookup(username)
       lookup = NucoreKfs::UconnUserLookup.new
       ldap_user = lookup.findByNetId(username)
+      if ldap_user.nil?
+        return nil
+      end
       lookup.makeNucoreUserFromLdapUser(ldap_user)
     end
 

--- a/vendor/engines/nucore_kfs/lib/tasks/nucore_kfs_tasks.rake
+++ b/vendor/engines/nucore_kfs/lib/tasks/nucore_kfs_tasks.rake
@@ -36,7 +36,7 @@ task :kfs_collector_export_cron, [:export_dir] => :environment do |_t, args|
     export_content = exporter.generate_export_file_new(rows_to_export)
 
     file_name = "journal-#{journal.id}.data"
-    export_file = File.join(export_dir, file_name);
+    export_file = File.join(export_dir, file_name)
     File.open(export_file, "w") { |file| file.write export_content }
 
     puts("Exported a Journal to #{export_file}")
@@ -168,24 +168,18 @@ end
 
 desc "LDAP test"
 task :ldap_test, [:csv_file_path] => :environment do |_t, args|
-  # csv_file_path = args.csv_file_path
-
   config_file_path = Rails.root.join("config", "ldap.yml")
   parsed = ERB.new(File.read(config_file_path)).result
-  # safe_load(yaml, whitelist_classes, whitelist_symbols, allow_aliases)
   yaml = YAML.safe_load(parsed, [], [], true) || {}
   config = yaml.fetch(Rails.env, {})
 
   host = config.fetch("host", "")
-  puts("host = #{host}")
-
   ldap = Net::LDAP.new(:encryption => {:method => :start_tls})
   ldap.host = config.fetch("host", "")
   ldap.port = config.fetch("port", "")
 
   admin_user = config.fetch("admin_user", "")
   admin_password = config.fetch("admin_password", "")
-  puts("admin_password = #{admin_password}")
   
   ldap.auth admin_user, admin_password
 

--- a/vendor/engines/nucore_kfs/spec/services/collector_transaction_spec.rb
+++ b/vendor/engines/nucore_kfs/spec/services/collector_transaction_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe NucoreKfs::CollectorTransaction, type: :service do
   let(:invalid_account) { FactoryBot.create(:nufs_account, :with_account_owner, owner: user, account_number: "INVALID-7777777-4444") }
 
   context "in open journal with invalid account" do
-    let(:transaction) { described_class.new(journal_rows.first) }
+    let(:transaction) { described_class.new(journal_rows.first, 1) }
     let(:journal) { FactoryBot.create(:kfs_journal, facility: facility) }
     let(:order_detail) { place_and_complete_kfs_item_order(user, facility, invalid_account, true) }
     let(:journal_rows) {

--- a/vendor/engines/nucore_kfs/spec/services/uconn_user_lookup_spec.rb
+++ b/vendor/engines/nucore_kfs/spec/services/uconn_user_lookup_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe NucoreKfs::UconnUserLookup, type: :service do
+
+  let(:valid_netid) { "jpo08003" }
+  let(:invalid_netid) { "jpo08003213213121313" }
+  let(:lookup) { described_class.new }
+
+  it "sucessfully binds to LDAP" do
+    expect(lookup.status).to be_truthy
+  end
+
+  it "can find a user by NetID" do
+    user = lookup.findByNetId(valid_netid)
+    expect(user).not_to be_nil
+  end
+
+  it "returns nil for invalid netid" do
+    user = lookup.findByNetId(invalid_netid)
+    expect(user).to be_nil
+  end
+
+  it "gets the correct attributes for a user" do
+    user = lookup.findByNetId(valid_netid)
+    expect(user.uid).to eq(valid_netid)
+    expect(user.cn).to eq("Joseph P O'Shea")
+    expect(user.givenname).to eq("Joseph")
+  end
+
+end

--- a/vendor/engines/nucore_kfs/spec/services/uconn_user_lookup_spec.rb
+++ b/vendor/engines/nucore_kfs/spec/services/uconn_user_lookup_spec.rb
@@ -6,21 +6,21 @@ RSpec.describe NucoreKfs::UconnUserLookup, type: :service do
   let(:invalid_netid) { "jpo08003213213121313" }
   let(:lookup) { described_class.new }
 
-  it "sucessfully binds to LDAP" do
+  it "sucessfully binds to LDAP", :if => ENV['VPN_ENABLED'] do
     expect(lookup.status).to be_truthy
   end
 
-  it "can find a user by NetID" do
+  it "can find a user by NetID", :if => ENV['VPN_ENABLED'] do
     user = lookup.findByNetId(valid_netid)
     expect(user).not_to be_nil
   end
 
-  it "returns nil for invalid netid" do
+  it "returns nil for invalid netid", :if => ENV['VPN_ENABLED'] do
     user = lookup.findByNetId(invalid_netid)
     expect(user).to be_nil
   end
 
-  it "gets the correct attributes for a user" do
+  it "gets the correct attributes for a user", :if => ENV['VPN_ENABLED'] do
     user = lookup.findByNetId(valid_netid)
     expect(user.uid).to eq(valid_netid)
     expect(user.cn).to eq("Joseph P O'Shea")


### PR DESCRIPTION
# Release Notes

Adds support for query UConn's LDAP for:
- adding new users via the web UI
- creating users accounts during the KFS accounts ETL in cases where an account is associated with a NetID for which we do not have a User record in our DB