### PR TITLE
Change kfs collector export file total sums by using money class

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ PATH
   remote: vendor/engines/nucore_kfs
   specs:
     nucore_kfs (0.0.2)
+      money (~> 6.16.0)
       rails (~> 5.2.3)
       savon (~> 2.12.0)
 
@@ -371,6 +372,8 @@ GEM
     minitest (5.14.2)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
+    money (6.16.0)
+      i18n (>= 0.6.4, <= 2)
     msgpack (1.3.3)
     mysql2 (0.5.3)
     nested_form_fields (0.8.4)

--- a/vendor/engines/nucore_kfs/Gemfile.lock
+++ b/vendor/engines/nucore_kfs/Gemfile.lock
@@ -80,6 +80,8 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
+    money (6.16.0)
+      i18n (>= 0.6.4, <= 2)
     nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
@@ -145,6 +147,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  money
   nucore_kfs!
 
 BUNDLED WITH

--- a/vendor/engines/nucore_kfs/nucore_kfs.gemspec
+++ b/vendor/engines/nucore_kfs/nucore_kfs.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", "~> 5.2.3"
   s.add_dependency 'savon', '~> 2.12.0'
+  s.add_dependency "money", '~> 6.16.0'
 end

--- a/vendor/engines/nucore_kfs/spec/factories/collector_transaction.rb
+++ b/vendor/engines/nucore_kfs/spec/factories/collector_transaction.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :collector_transaction, class: NucoreKfs::CollectorTransaction do
+    document_number { 1 }
+    journal_row
+    transaction_dollar_amount { 1.01 }
+
+    initialize_with { new(journal_row, document_number) }
+  end
+end


### PR DESCRIPTION
# Release Notes

This PR fixes a bug with our KFS export. Due to using floats for currency amounts, some cases could lead to an incorrect sum for the total amount of transactions in a KFS Collector export file. By using the [money](https://github.com/RubyMoney/money) class instead of floats, we fix this problem.

This PR also adds a test to check for this regression.